### PR TITLE
Remove chai and dirty chai from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,6 @@
   },
   "devDependencies": {
     "aegir": "^18.0.3",
-    "chai": "^4.1.2",
-    "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "~0.4.17",
     "mock-require": "^3.0.2",
     "npm-run-all": "^4.1.3",


### PR DESCRIPTION
Looks like the tests that used chai got moved out to seperate modules in https://github.com/ipfs-shipyard/npm-on-ipfs/commit/1100ff6bc67d6cd7156853e63c9352c730e49008#diff-3dcfe508eca97a681a25f38300c9d678