### PR TITLE
feat: support config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,16 @@ Options:
                                 unavailable
                                          [default: "https://registry.npmjs.com"]
 ```
+
+## Configuration File
+
+We use [`rc`](https://github.com/dominictarr/rc) to parse configuration files. You can take a look
+at their order of precende when searching for configuration files on [their repository](https://github.com/dominictarr/rc#standards). Our app is `ipfsnpm`.
+
+For instance, if you want to always use a remote daemon, you could create a `~/.ipfsnpmrc` file like this:
+
+```json
+{
+  "ipfsNode": "/ip4/127.0.0.1/tcp/5001"
+}
+```

--- a/README.md
+++ b/README.md
@@ -124,8 +124,6 @@ Options:
 
 We use [`rc`](https://github.com/dominictarr/rc) to parse configuration files. Please see the [`rc` repository](https://github.com/dominictarr/rc#standards) for the order of precedence used when searching for configuration files. Our app is `ipfs-npm`.
 
-Please see the rc repository for the order of precedence used when searching for configuration files.
-
 For instance, if you want to always use a remote daemon, you could create a `~/.ipfs-npmrc` file like this:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ Options:
 
 ## Configuration File
 
-We use [`rc`](https://github.com/dominictarr/rc) to parse configuration files. You can take a look
-at their order of precende when searching for configuration files on [their repository](https://github.com/dominictarr/rc#standards). Our app is `ipfsnpm`.
+We use [`rc`](https://github.com/dominictarr/rc) to parse configuration files. Please see the [`rc` repository](https://github.com/dominictarr/rc#standards) for the order of precedence used when searching for configuration files. Our app is `ipfs-npm`.
 
-For instance, if you want to always use a remote daemon, you could create a `~/.ipfsnpmrc` file like this:
+Please see the rc repository for the order of precedence used when searching for configuration files.
+
+For instance, if you want to always use a remote daemon, you could create a `~/.ipfs-npmrc` file like this:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ipfsd-ctl": "~0.40.1",
     "ipfs-registry-mirror-common": "^1.0.13",
     "once": "^1.4.0",
+    "rc": "^1.2.8",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "which-promise": "^1.0.0",

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -12,7 +12,7 @@ const rc = require('rc')
 process.title = pkg.name
 
 const yargs = require('yargs')
-  .config(rc('npm-on-ipfs', null, {}))
+  .config(rc('ipfsnpm', null, {}))
 
 yargs.command('$0', 'Installs your js dependencies using IPFS', (yargs) => { // eslint-disable-line no-unused-expressions
   yargs

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -12,7 +12,7 @@ const rc = require('rc')
 process.title = pkg.name
 
 const yargs = require('yargs')
-  .config(rc('ipfsnpm', null, {}))
+  .config(rc(pkg.name, null, {}))
 
 yargs.command('$0', 'Installs your js dependencies using IPFS', (yargs) => { // eslint-disable-line no-unused-expressions
   yargs

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -7,10 +7,12 @@ require('dnscache')({ enable: true })
 const pkg = require('../../package')
 const path = require('path')
 const os = require('os')
+const rc = require('rc')
 
 process.title = pkg.name
 
 const yargs = require('yargs')
+  .config(rc('npm-on-ipfs', null, {}))
 
 yargs.command('$0', 'Installs your js dependencies using IPFS', (yargs) => { // eslint-disable-line no-unused-expressions
   yargs


### PR DESCRIPTION
This PR adds the [`rc` package](https://github.com/dominictarr/rc) which with one line allows us to have configuration files so we don't need to set all flags we want every time we run the CLI.

The application name is `ipfsnpm`, hence it will look for a configuration file on the following paths:

1. ./.ipfsnpmrc
2. $HOME/.ipfsnpmrc
3. $HOME/.ipfsnpm/config
4. $HOME/.config/ipfsnpm
5. $HOME/.config/ipfsnpm/config
6. /etc/ipfsnpmrc
7. /etc/ipfsnpm/config

This will help us with adding npm-on-ipfs support on IPFS desktop by letting us easily configure which daemon to use by default (see https://github.com/ipfs-shipyard/ipfs-desktop/pull/911).

This also closes #83.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>