### PR TITLE
feat: script to compare fresh install time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@ test
 dist
 img
 ci
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Build ipfs-npm from src
+FROM node:10.15.3
+MAINTAINER olizilla <oli@tableflip.io>
+
+WORKDIR /opt/npm-on-ipfs
+
+# Create a docker cache layer for just the deps. This means less rebuilding if
+# only the source code changes
+COPY package.json /opt/npm-on-ipfs
+RUN npm install --quiet
+
+# Copy
+COPY ./src /opt/npm-on-ipfs/src
+RUN npm link

--- a/test/perf/docker-race.sh
+++ b/test/perf/docker-race.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Compare the first install times of a module via npm and ipfs-npm.
+# Using Docker here to ensure we are using fresh caches for each run.
+#
+# Usage:
+#
+#    ./docker-race.sh [npm module]
+#
+# NOTE: On first run this will create a local image called ipfs-npm, from the
+# Dockerfile at the root of this project. To update it with the latest source,
+# rebuild the image:
+#
+#    docker build -t ipfs-npm .
+#
+# or simply delete it and let the script re-build it
+#
+#    docker image rm ipfs-npm -f
+#
+MODULE=${1:-iim}
+IMAGE=ipfs-npm
+
+if $(docker image ls | grep -q $IMAGE)
+then
+  echo "found ipfs-npm Docker image"
+else
+  echo "building docker image for ipfs-npm, this will take a moment"
+  docker build -t $IMAGE ../../
+fi
+
+echo ""
+echo "---- ipfs-npm flavour ----"
+time docker run $IMAGE ipfs-npm install -g $MODULE
+
+echo ""
+echo "---- npm flavour ----"
+time docker run node:10.15.3 npm install -g $MODULE


### PR DESCRIPTION
A script to repeatably compare the first install time of a module via `ipfs-npm` against `npm`.

We know `ipfs-npm` is likely to be slower on first install time, but I want to do whatever we can to bring that time down, as it's the first experience folks will have with it.

We create a docker image with `ipfs-npm` in, then time how long it take to install takes there, then run the same install again in a stock `node` docker image via `npm`. Both will have empty caches for the run.

### Example output

```console
$ ./test/perf/docker-race.sh 
found ipfs-npm Docker image

---- ipfs-npm flavour ----
👿 Spawning an in-process IPFS node using repo at /root/.jsipfs
...
/usr/local/bin/iim -> /usr/local/lib/node_modules/iim/src/bin.js
+ iim@0.6.1
added 415 packages from 782 contributors in 115.216s
🎁 /usr/local/bin/npm exited with code 0
🔏 Updating package-lock.json

real	2m0.062s
user	0m0.033s
sys	0m0.024s

---- npm flavour ----
/usr/local/bin/iim -> /usr/local/lib/node_modules/iim/src/bin.js
+ iim@0.6.1
added 415 packages from 782 contributors in 8.459s

real	0m10.811s
user	0m0.032s
sys	0m0.014s
```

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>