### PR TITLE
chore: remove unneeded asyncs

### DIFF
--- a/src/core/commands/start-ipfs.js
+++ b/src/core/commands/start-ipfs.js
@@ -31,22 +31,16 @@ const startIpfs = async (config) => {
       repoPath: config.ipfs.repo
     })
 
-    return new Promise(async (resolve, reject) => {
-      try {
-        const initalise = promisify(node.init.bind(node))
-        const start = promisify(node.start.bind(node))
+    const initalise = promisify(node.init.bind(node))
+    const start = promisify(node.start.bind(node))
 
-        if (!node.initialized) {
-          await initalise()
-        }
+    if (!node.initialized) {
+      await initalise()
+    }
 
-        await start()
+    await start()
 
-        resolve(node)
-      } catch (error) {
-        reject(error)
-      }
-    })
+    return node
   } else if (config.ipfs.node === 'disposable') {
     console.info('👿 Spawning an in-process disposable IPFS node') // eslint-disable-line no-console
 

--- a/src/core/commands/start-server.js
+++ b/src/core/commands/start-server.js
@@ -37,7 +37,7 @@ const startServer = (config, ipfs) => {
 
   app.locals.ipfs = ipfs
 
-  return new Promise(async (resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const callback = once((error) => {
       if (error) {
         reject(error)


### PR DESCRIPTION
As I'll tackle https://github.com/ipfs-shipyard/npm-on-ipfs/issues/105 in the near future, I was taking a look at the code to start ipfs, and found some unneeded `async` and `new Promise` that could be simplified.

/cc @achingbrain @olizilla 