### PR TITLE
feat: use ipfs-provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ As the largest software registry in the world, [npm](https://www.npmjs.com) is a
 The result is npm-on-ipfs: a module that wraps your package manager of choice (npm or yarn) in configuration to use [IPFS](https://ipfs.io/), not HTTP, to retrieve your dependencies from the central npm registry. It's still a work in progress, but we think you'll find it useful and awesome for the following reasons:
 
  - Having dependencies on the distributed web makes development **more available** because multiple nodes supplying tarballs means no panic if a single source goes dark
- - It can also be **faster and cheaper** — if dependencies are already being hosted on your local network, this means lower bandwidth cost and higher speed 
+ - It can also be **faster and cheaper** — if dependencies are already being hosted on your local network, this means lower bandwidth cost and higher speed
  - If enough dependencies are hosted on your local network (think enterprise or community development settings), that network can operate **offline-first**: Take your team on a remote mountain retreat and hack away!
 
 ## Install & use
@@ -85,6 +85,8 @@ Options:
                                 timing out                       [default: 5000]
   --ipfs-mfs-prefix             Which mfs prefix to use
                                                       [default: "/npm-registry"]
+  --ipfs-disable-providers      Wether to disable the search for running nodes
+                                                                [default: false]
   --ipfs-node                   "proc" to start an in-process IPFS node,
                                 "disposable" to start an in-process disposable
                                 node, "go" or "js" to spawn an IPFS node as a

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "express": "^4.16.4",
     "express-http-proxy": "^1.5.1",
     "ipfs": "^0.36.3",
-    "ipfs-http-client": "^32.0.1",
+    "ipfs-provider": "^0.2.1",
     "ipfs-registry-mirror-common": "^1.0.13",
     "ipfsd-ctl": "~0.42.2",
     "once": "^1.4.0",

--- a/src/cli/bin.js
+++ b/src/cli/bin.js
@@ -46,6 +46,11 @@ yargs.command('$0', 'Installs your js dependencies using IPFS', (yargs) => { // 
       describe: 'Which mfs prefix to use',
       default: '/npm-registry'
     })
+    .option('ipfs-disable-providers', {
+      describe: 'Whether to disable the search for running nodes',
+      type: 'boolean',
+      default: false
+    })
     .option('ipfs-node', {
       describe: '"proc" to start an in-process IPFS node, "disposable" to start an in-process disposable node, "go" or "js" to spawn an IPFS node as a separate process or a multiaddr that resolves to a running node',
       default: 'proc'

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -15,6 +15,7 @@ module.exports = (overrides = {}) => {
     ipfs: {
       host: option(process.env.IPFS_HOST, overrides.ipfsHost),
       port: option(Number(process.env.IPFS_PORT), overrides.ipfsPort),
+      disableProviders: option(process.env.IPFS_DISABLE_PROVIDERS, overrides.ipfsDisableProviders),
       node: option(process.env.IPFS_NODE, overrides.ipfsNode),
       prefix: option(process.env.IPFS_MFS_PREFIX, overrides.ipfsMfsPrefix),
       flush: option(process.env.IPFS_FLUSH, overrides.ipfsFlush),


### PR DESCRIPTION
- Removes `js-ipfs-http-client` in favour of `ipfs-provider`
- Adds an option that checks if a node is running on the default port
	- If there is, connects to it
	- If there isn't, the previous behaviour happens (spawns an in-process node)
	- To disable this check just pass `--ipfs-disable-providers`, it's enabled by default